### PR TITLE
Update formula to depends on 'sdl' package

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -70,6 +70,7 @@ class Mpv < Formula
   depends_on 'jpeg'
   depends_on 'libbluray'
   depends_on 'libaacs'
+  depends_on 'sdl'
 
   if libav?
     depends_on 'mpv-player/mpv/libav'


### PR DESCRIPTION
I'm was to compile `mpv` after I remove the sdl package:

```
[~] brew install --HEAD mpv
==> Cloning https://github.com/mpv-player/mpv.git
Updating /Library/Caches/Homebrew/mpv--git
==> Generating VERSION file from Homebrew's git cache
==> ./configure --prefix=/usr/local/Cellar/mpv/HEAD --cc=cc --enable-macosx-bundle --disable-x11
==> make install
==> make osxbundle
> copying binary
> generating Info.plist
> bundling dependencies
mpv.app/Contents/MacOS/lib/libavutil.52.18.100.dylib uses library /usr/local/lib/libSDL-1.2.0.dylib which is not available anymore
make: *** [osxbundle] Error 1

READ THIS: https://github.com/mxcl/homebrew/wiki/troubleshooting
```
