### PR TITLE
libav: add freetype dependency

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -10,6 +10,7 @@ class Libav < Formula
 
   depends_on 'pkg-config' => :build
   depends_on 'yasm' => :build
+  depends_on :freetype => build
 
   depends_on 'x264' => :optional
   depends_on 'faac' => :optional


### PR DESCRIPTION
build error occured because of 'ERROR: freetype2 not found'

https://gist.github.com/henry0312/6194134
