### PR TITLE
Add vapoursynth to mpv formula

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -85,7 +85,7 @@ class Mpv < Formula
 
     if build.with? 'vapoursynth'
       pyver = Language::Python.major_minor_version Formula['python3'].bin/'python3'
-      ENV.append_path 'PKG_CONFIG_PATH', Formula['python3'].frameworks/"Python.framework/Versions/#{pyver}/lib/pkgconfig"
+      ENV.append_path 'PKG_CONFIG_PATH', Formula['python3'].frameworks/'Python.framework/Versions'/pyver/'lib/pkgconfig'
     end
 
     args = [ "--prefix=#{prefix}" ]


### PR DESCRIPTION
This would fix #33.
I'm not experienced with homebrew formula at all, so feel free to reject and do it in a better way, but I wanted to propose this nevertheless.

l.86-90 makes the `pkgconfig` path of python3 visible to the build. The way it is done was suggested by a homebrew maintainer so I hope it's fine.
l.10 uses `'python3'` instead of `:python3` because I guess l.86-90 might work only with a homebrew installed python3.
