### PR TITLE
mpv: require 'with-harfbuzz' option of libass or libass-ct

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -31,9 +31,9 @@ class Mpv < Formula
   option 'without-zsh-comp',     'Install without zsh completion'
 
   if build.with? 'official-libass'
-    depends_on 'libass'
+    depends_on 'libass' => 'with-harfbuzz'
   else
-    depends_on 'mpv-player/mpv/libass-ct'
+    depends_on 'mpv-player/mpv/libass-ct' => 'with-harfbuzz'
   end
 
   depends_on 'ffmpeg'


### PR DESCRIPTION
According to README of mpv, harfbuzz is

> required for correct rendering of combining characters, particularly for correct rendering of non-English text on OSX, and Arabic/Indic scripts on any platform.

See [mpv#1492: Filename handling on OS X: NFD used, should use NFC](https://github.com/mpv-player/mpv/issues/1492) for discussion of how things go wrong when libass is not compiled with harfbuzz.