### PR TITLE
Vapoursynth's formula should contain SHA1 checksum for Cython

### DIFF
--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -28,6 +28,7 @@ class Vapoursynth < Formula
   resource 'cython' do
     url 'https://pypi.python.org/packages/source/C/Cython/Cython-0.21.2.tar.gz'
     md5 'd21adb870c75680dc857cd05d41046a4'
+    sha1 'c3fe3dd5693aa09719ee4a3bcec898068c82592d'
   end
 
   def install


### PR DESCRIPTION
It seems that new version of Homebrew requires SHA1 checksum to be present in formula in order to proceed with installation (I believe it used to raise a warning, now it interrupts the installation process with error). Vapoursynth's formula doesn't currently contain SHA1 checksum for Cython – could it be added?

Of course, please feel free to recalculate the SHA1 checksum, don't trust me. I'm creating this as a pull request rather than just regular issue just for the sake of your convenience, I hope that's okey :smile: 