### PR TITLE
harfbuzz.rb: update to 0.9.40

### DIFF
--- a/Formula/harfbuzz.rb
+++ b/Formula/harfbuzz.rb
@@ -1,7 +1,7 @@
 class Harfbuzz < Formula
   homepage "http://www.freedesktop.org/wiki/Software/HarfBuzz"
-  url "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.38.tar.bz2"
-  sha256 "6736f383b4edfcaaeb6f3292302ca382d617d8c79948bb2dd2e8f86cdccfd514"
+  url "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-0.9.40.tar.bz2"
+  sha256 "1771d53583be6d91ca961854b2a24fb239ef0545eed221ae3349abae0ab8321f"
 
   depends_on "pkg-config" => :build
   depends_on "freetype"


### PR DESCRIPTION
Taken directly [from homebrew](https://github.com/Homebrew/homebrew/blob/e3edfcc857b9f55240765a34cd67477624cd28e6/Library/Formula/harfbuzz.rb).