### PR TITLE
Remove libbs2b option

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -28,7 +28,6 @@ class Mpv < Formula
   depends_on 'jpeg'        => :recommended
 
   depends_on 'libcaca'     => :optional
-  depends_on 'libbs2b'     => :optional
   depends_on 'libdvdread'  => :optional
   depends_on 'libdvdnav'   => :optional
   depends_on 'little-cms2' => :recommended


### PR DESCRIPTION
With mpv 0.11.0 released, the support for the bs2b filter was removed in favor of the libavfilter's implementation, and Homebrew/homebrew@867d2a3 added an option to compile ffmpeg with it.
