### PR TITLE
libass-git => libass

### DIFF
--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -16,14 +16,7 @@ class Vapoursynth < Formula
 
   depends_on 'ffmpeg'
   depends_on 'tesseract'
-
-  option 'with-official-libass', 'Use official version of libass'
-
-  if build.with? 'official-libass'
-    depends_on 'libass' => 'with-harfbuzz'
-  else
-    depends_on 'mpv-player/mpv/libass-git'
-  end
+  depends_on 'libass'
 
   resource 'cython' do
     url 'https://pypi.python.org/packages/source/C/Cython/Cython-0.21.2.tar.gz'


### PR DESCRIPTION
Libass-git is dropped, remove it from vapoursynth's depencencies.