### PR TITLE
mpv: always build (L)GPLv3 code

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -54,7 +54,9 @@ class Mpv < Formula
       ENV.append_path "PKG_CONFIG_PATH", python3_pkg_config_path
     end
 
-    args = ["--prefix=#{prefix}"]
+    args = ["--prefix=#{prefix}",
+            "--enable-gpl3"
+           ]
     args << "--enable-libmpv-shared" if build.with? "libmpv"
     args << "--enable-zsh-comp" if build.with? "zsh-comp"
 


### PR DESCRIPTION
As discussed in #92, this always enables building the LGPLv3 code.